### PR TITLE
feat(agent): add agent-based backend with memory and API endpoint

### DIFF
--- a/app/lib/agents/executor.ts
+++ b/app/lib/agents/executor.ts
@@ -1,0 +1,28 @@
+import type { PlannedTask } from './planner';
+import { globalMemory } from './memory';
+
+export class Executor {
+  async execute(sessionId: string, task: PlannedTask): Promise<string> {
+    switch (task.type) {
+      case 'time':
+        return new Date().toISOString();
+      case 'calc':
+        try {
+          // eslint-disable-next-line no-eval
+          return eval(task.input).toString();
+        } catch {
+          return 'error';
+        }
+      case 'recall':
+        return globalMemory
+          .search(sessionId, task.input)
+          .map((m) => m.text)
+          .join('\n');
+      case 'respond':
+        globalMemory.add(sessionId, task.input);
+        return '';
+      default:
+        return '';
+    }
+  }
+}

--- a/app/lib/agents/index.ts
+++ b/app/lib/agents/index.ts
@@ -1,0 +1,22 @@
+import { Planner } from './planner';
+import type { PlannedTask } from './planner';
+import { Executor } from './executor';
+
+export interface AgentStep {
+  task: PlannedTask;
+  result: string;
+}
+
+export async function runAgent(sessionId: string, input: string): Promise<AgentStep[]> {
+  const planner = new Planner();
+  const executor = new Executor();
+  const plan = planner.plan(input);
+  const steps: AgentStep[] = [];
+
+  for (const task of plan) {
+    const result = await executor.execute(sessionId, task);
+    steps.push({ task, result });
+  }
+
+  return steps;
+}

--- a/app/lib/agents/memory.ts
+++ b/app/lib/agents/memory.ts
@@ -1,0 +1,55 @@
+export interface MemoryRecord {
+  text: string;
+  embedding: number[];
+}
+
+/**
+ * Simple in-memory vector store. In a production system this could be backed
+ * by an external vector database such as Pinecone or pgvector. For the
+ * purposes of this repo we keep things in memory so tests can run deterministically.
+ */
+export class MemoryStore {
+  private _store = new Map<string, MemoryRecord[]>();
+
+  private _encode(text: string): number[] {
+    const vec = [0, 0, 0];
+
+    for (const ch of text) {
+      const code = ch.charCodeAt(0);
+      vec[0] += code;
+      vec[1] += code % 101;
+      vec[2] += code % 17;
+    }
+
+    return vec;
+  }
+
+  private _cosine(a: number[], b: number[]): number {
+    const dot = a.reduce((acc, v, i) => acc + v * b[i], 0);
+    const magA = Math.sqrt(a.reduce((acc, v) => acc + v * v, 0));
+    const magB = Math.sqrt(b.reduce((acc, v) => acc + v * v, 0));
+
+    return magA && magB ? dot / (magA * magB) : 0;
+  }
+
+  add(sessionId: string, text: string) {
+    const embedding = this._encode(text);
+    const list = this._store.get(sessionId) ?? [];
+
+    list.push({ text, embedding });
+    this._store.set(sessionId, list);
+  }
+
+  search(sessionId: string, query: string, topK = 3): MemoryRecord[] {
+    const list = this._store.get(sessionId) ?? [];
+    const queryEmbedding = this._encode(query);
+
+    return list
+      .map((record) => ({ record, score: this._cosine(queryEmbedding, record.embedding) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+      .map((r) => r.record);
+  }
+}
+
+export const globalMemory = new MemoryStore();

--- a/app/lib/agents/planner.ts
+++ b/app/lib/agents/planner.ts
@@ -1,0 +1,31 @@
+export type TaskType = 'recall' | 'time' | 'calc' | 'respond';
+
+export interface PlannedTask {
+  type: TaskType;
+  input: string;
+}
+
+/**
+ * Very small heuristic planner. A real planner could use a language model to
+ * break down complex problems into steps. Here we look for a couple of keywords
+ * and always include a recall step so the agent can use prior context.
+ */
+export class Planner {
+  plan(input: string): PlannedTask[] {
+    const tasks: PlannedTask[] = [{ type: 'recall', input }];
+
+    if (/time/i.test(input)) {
+      tasks.push({ type: 'time', input: '' });
+    }
+
+    const calcMatch = input.match(/(\d+\s*[+\-*/]\s*\d+)/);
+
+    if (calcMatch) {
+      tasks.push({ type: 'calc', input: calcMatch[1] });
+    }
+
+    tasks.push({ type: 'respond', input });
+
+    return tasks;
+  }
+}

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -1,0 +1,11 @@
+import type { ActionFunctionArgs } from '@remix-run/cloudflare';
+import { runAgent } from '~/lib/agents';
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { sessionId = 'default', input } = await request.json<{ sessionId?: string; input: string }>();
+  const steps = await runAgent(sessionId, input);
+
+  return new Response(JSON.stringify({ steps }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## Summary
- introduce simple planner/executor agents with in-memory vector store
- expose `/api/agent` endpoint to run agent flows

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf88c72348328871b13f8a0f63325