### PR TITLE
feat: add project planning documentation service

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -28,6 +28,7 @@ import type { ElementInfo } from '~/components/workbench/Inspector';
 import type { TextUIPart, FileUIPart, Attachment } from '@ai-sdk/ui-utils';
 import { useMCPStore } from '~/lib/stores/mcp';
 import type { LlmErrorAlertType } from '~/types/actions';
+import { ProjectPlanningService } from '~/lib/services/projectPlanningService';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -209,6 +210,16 @@ export const ChatImpl = memo(
       initialMessages,
       initialInput: Cookies.get(PROMPT_COOKIE_KEY) || '',
     });
+
+    const planGenerated = useRef(false);
+    useEffect(() => {
+      if (messages.length === 1 && !planGenerated.current) {
+        planGenerated.current = true;
+        ProjectPlanningService.generatePlan(messages[0].content as string)
+          .then(({ plan, rules }) => ProjectPlanningService.applyPlan(plan, rules, workbenchStore))
+          .catch((error) => toast.error(error.message));
+      }
+    }, [messages]);
     useEffect(() => {
       const prompt = searchParams.get('prompt');
 

--- a/app/lib/services/projectPlanningService.ts
+++ b/app/lib/services/projectPlanningService.ts
@@ -1,0 +1,64 @@
+import { WORK_DIR } from '~/utils/constants';
+import type { WorkbenchStore } from '~/lib/stores/workbench';
+import type { FilesStore } from '~/lib/stores/files';
+
+/**
+ * Service for generating and updating project planning documentation
+ */
+export class ProjectPlanningService {
+  static readonly PLAN_FILE = `${WORK_DIR}/PROJECT_PLAN.md`;
+  static readonly RULES_FILE = `${WORK_DIR}/RULES.md`;
+
+  /**
+   * Generate project plan and rules using the server-side API
+   * @param prompt Initial system prompt describing the project
+   */
+  static async generatePlan(prompt: string): Promise<{ plan: string; rules: string }> {
+    const res = await fetch('/api/project-plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+
+    if (!res.ok) {
+      throw new Error('Failed to generate project plan');
+    }
+
+    return res.json();
+  }
+
+  /**
+   * Create plan and rules files in the workbench
+   */
+  static async applyPlan(plan: string, rules: string, workbench: WorkbenchStore) {
+    await workbench.createFile(ProjectPlanningService.PLAN_FILE, plan);
+    await workbench.createFile(ProjectPlanningService.RULES_FILE, rules);
+  }
+
+  /**
+   * Mark corresponding task as complete in the plan when a file is created
+   */
+  static async markTaskComplete(filePath: string, filesStore: FilesStore) {
+    const plan = filesStore.getFile(ProjectPlanningService.PLAN_FILE);
+
+    if (!plan) {
+      return;
+    }
+
+    const relativePath = filePath.replace(`${WORK_DIR}/`, '');
+    const lines = plan.content.split('\n');
+    let updated = false;
+    const newLines = lines.map((line) => {
+      if (line.includes(relativePath) && line.trim().startsWith('- [ ]')) {
+        updated = true;
+        return line.replace('- [ ]', '- [x]');
+      }
+
+      return line;
+    });
+
+    if (updated) {
+      await filesStore.saveFile(ProjectPlanningService.PLAN_FILE, newLines.join('\n'));
+    }
+  }
+}

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -18,6 +18,7 @@ import { description } from '~/lib/persistence';
 import Cookies from 'js-cookie';
 import { createSampler } from '~/utils/sampler';
 import type { ActionAlert, DeployAlert, SupabaseAlert } from '~/types/actions';
+import { ProjectPlanningService } from '~/lib/services/projectPlanningService';
 
 const { saveAs } = fileSaver;
 
@@ -358,6 +359,12 @@ export class WorkbenchStore {
           const newUnsavedFiles = new Set(this.unsavedFiles.get());
           newUnsavedFiles.delete(filePath);
           this.unsavedFiles.set(newUnsavedFiles);
+        }
+
+        try {
+          await ProjectPlanningService.markTaskComplete(filePath, this.#filesStore);
+        } catch (err) {
+          console.error('Failed to update project plan', err);
         }
       }
 

--- a/app/routes/api.project-plan.ts
+++ b/app/routes/api.project-plan.ts
@@ -1,0 +1,33 @@
+import { json, type ActionFunctionArgs } from '@remix-run/cloudflare';
+import { generateText } from 'ai';
+import { LLMManager } from '~/lib/modules/llm/manager';
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from '~/utils/constants';
+
+export async function action({ request, context }: ActionFunctionArgs) {
+  const { prompt } = await request.json<{ prompt: string }>();
+
+  const manager = LLMManager.getInstance((context.cloudflare?.env as any) || {});
+  const provider = manager.getProvider(DEFAULT_PROVIDER.name) || manager.getDefaultProvider();
+  const model = provider.getModelInstance({
+    model: DEFAULT_MODEL,
+    serverEnv: context.cloudflare?.env,
+  });
+
+  const resp = await generateText({
+    model,
+    system:
+      'You are a project planning assistant. Given a project description, ' +
+      'generate a concise project plan and a list of development rules in markdown. ' +
+      'Output using the following format:\n<plan>\n# Project Plan\n- [ ] task\n</plan>\n<rules>\n# Rules\n- rule\n</rules>',
+    prompt,
+  });
+
+  const text = resp.text;
+  const planMatch = text.match(/<plan>([\s\S]*?)<\/plan>/i);
+  const rulesMatch = text.match(/<rules>([\s\S]*?)<\/rules>/i);
+
+  return json({
+    plan: planMatch ? planMatch[1].trim() : '',
+    rules: rulesMatch ? rulesMatch[1].trim() : '',
+  });
+}


### PR DESCRIPTION
## Summary
- generate project planning and rules with new LLM-powered API
- create project plan and rules markdown files at chat start
- update plan tasks automatically when files are created

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf81dc3b88328845db6ac65d303cc